### PR TITLE
Removed forced http on Angular animate

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -65,7 +65,7 @@
     <!-- ng-file-upload.js -->
     <script type="text/javascript" src="lib/plugins/ng-file-upload.js"></script>
     <!-- angular animate -->
-    <script src="http://ajax.googleapis.com/ajax/libs/angularjs/1.4.1/angular-animate.js"></script>
+    <script src="//ajax.googleapis.com/ajax/libs/angularjs/1.4.1/angular-animate.js"></script>
     <!-- app.js -->
     <script src="app/js/app.js" type="text/javascript"></script>
 


### PR DESCRIPTION
causes http/https mismatch while this works as-is and behind a reverse proxy with https